### PR TITLE
MAINT Input checks

### DIFF
--- a/src/multi_condition_comparisions/tl/de.py
+++ b/src/multi_condition_comparisions/tl/de.py
@@ -1,4 +1,3 @@
-from typing import List
 from abc import ABC, abstractmethod
 
 import numpy as np
@@ -8,10 +7,9 @@ import statsmodels.api as sm
 from anndata import AnnData
 from formulaic import model_matrix
 from formulaic.model_matrix import ModelMatrix
-from tqdm.auto import tqdm
-
 from scanpy import logging
 from scipy.sparse import issparse
+from tqdm.auto import tqdm
 
 
 class BaseMethod(ABC):
@@ -48,11 +46,6 @@ class BaseMethod(ABC):
         # Check that counts have no NaN or Inf values.
         if np.any(np.isnan(self.adata.X)) or np.any(np.isinf(self.adata.X)):
             raise ValueError("Counts cannot contain NaN or Inf values.")
-        # Check that counts are non-negative integers.
-        if np.any(self.adata.X < 0) or not np.issubdtype(
-            self.adata.X.dtype, np.integer
-        ):
-            raise ValueError("Counts must be non-negative integers.")
 
         self.layer = layer
         if isinstance(design, str):
@@ -81,9 +74,7 @@ class BaseMethod(ABC):
     def _test_single_contrast(self, contrast, **kwargs) -> pd.DataFrame:
         ...
 
-    def test_contrasts(
-        self, contrasts: dict[str, np.ndarray] | np.ndarray, **kwargs
-    ) -> pd.DataFrame:
+    def test_contrasts(self, contrasts: dict[str, np.ndarray] | np.ndarray, **kwargs) -> pd.DataFrame:
         """
         Conduct a specific test
 
@@ -100,9 +91,7 @@ class BaseMethod(ABC):
             contrasts = {None: contrasts}
         results = []
         for name, contrast in contrasts.items():
-            results.append(
-                self._test_single_contrast(contrast, **kwargs).assign(contrast=name)
-            )
+            results.append(self._test_single_contrast(contrast, **kwargs).assign(contrast=name))
         return pd.concat(results)
 
     def test_reduced(self, modelB: "BaseMethod") -> pd.DataFrame:
@@ -226,19 +215,18 @@ class EdgeRDE(BaseMethod):
         **kwargs
             Keyword arguments specific to glmQLFit()
         """
-
         ## For running in notebook
         # pandas2ri.activate()
         # rpy2.robjects.numpy2ri.activate()
 
         ## -- Check installations
         try:
-            import rpy2.robjects.pandas2ri
             import rpy2.robjects.numpy2ri
-            from rpy2.robjects.packages import importr
-            from rpy2.robjects import pandas2ri, numpy2ri
-            from rpy2.robjects.conversion import localconverter
+            import rpy2.robjects.pandas2ri
             from rpy2 import robjects as ro
+            from rpy2.robjects import numpy2ri, pandas2ri
+            from rpy2.robjects.conversion import localconverter
+            from rpy2.robjects.packages import importr
 
             pandas2ri.activate()
             rpy2.robjects.numpy2ri.activate()
@@ -255,8 +243,7 @@ class EdgeRDE(BaseMethod):
             bcparallel = importr("BiocParallel")
         except ImportError:
             raise ImportError(
-                "edgeR requires a valid R installation with the following packages: "
-                "edgeR, BiocParallel, RhpcBLASctl"
+                "edgeR requires a valid R installation with the following packages: " "edgeR, BiocParallel, RhpcBLASctl"
             )
 
         ## -- Feature selection
@@ -271,9 +258,7 @@ class EdgeRDE(BaseMethod):
             else:
                 expr = expr.T
 
-        expr_r = ro.conversion.py2rpy(
-            pd.DataFrame(expr, index=self.adata.var_names, columns=self.adata.obs_names)
-        )
+        expr_r = ro.conversion.py2rpy(pd.DataFrame(expr, index=self.adata.var_names, columns=self.adata.obs_names))
 
         ## -- Convert to DGE
         dge = edger.DGEList(counts=expr_r, samples=self.adata.obs)
@@ -293,7 +278,7 @@ class EdgeRDE(BaseMethod):
         # self.adata.uns["fit"] = fit
         self.fit = fit
 
-    def _test_single_contrast(self, contrast: List[str]) -> pd.DataFrame:
+    def _test_single_contrast(self, contrast: list[str]) -> pd.DataFrame:
         """
         Conduct test for each contrast and return a data frame
 
@@ -303,7 +288,6 @@ class EdgeRDE(BaseMethod):
             numpy array of integars indicating contrast
             i.e. [-1, 0, 1, 0, 0]
         """
-
         ## For running in notebook
         # pandas2ri.activate()
         # rpy2.robjects.numpy2ri.activate()
@@ -314,12 +298,12 @@ class EdgeRDE(BaseMethod):
 
         ## -- Check installations
         try:
-            import rpy2.robjects.pandas2ri
             import rpy2.robjects.numpy2ri
-            from rpy2.robjects.packages import importr
-            from rpy2.robjects import pandas2ri, numpy2ri
-            from rpy2.robjects.conversion import localconverter
+            import rpy2.robjects.pandas2ri
             from rpy2 import robjects as ro
+            from rpy2.robjects import numpy2ri, pandas2ri
+            from rpy2.robjects.conversion import localconverter
+            from rpy2.robjects.packages import importr
 
         except ImportError:
             raise ImportError("edger requires rpy2 to be installed. ")
@@ -333,8 +317,7 @@ class EdgeRDE(BaseMethod):
             bcparallel = importr("BiocParallel")
         except ImportError:
             raise ImportError(
-                "edgeR requires a valid R installation with the following packages: "
-                "edgeR, BiocParallel, RhpcBLASctl"
+                "edgeR requires a valid R installation with the following packages: " "edgeR, BiocParallel, RhpcBLASctl"
             )
 
         ## -- Get fit object

--- a/src/multi_condition_comparisions/tl/de.py
+++ b/src/multi_condition_comparisions/tl/de.py
@@ -50,6 +50,11 @@ class BaseMethod(ABC):
         if not np.issubdtype(self.adata.X.dtype, np.number):
             raise ValueError("Counts must be numeric.")
 
+        # Check that counts are valid for the specific method.
+        if not self._check_counts():
+            # TODO: return a more informative error message depending on the actual issue
+            raise ValueError("Counts are not valid for this method.")
+
         self.layer = layer
         if isinstance(design, str):
             self.design = model_matrix(design, adata.obs)
@@ -60,6 +65,20 @@ class BaseMethod(ABC):
     def variables(self):
         """Get the names of the variables used in the model definition"""
         return self.design.model_spec.variables_by_source["data"]
+
+    @abstractmethod
+    def _check_counts(self) -> bool:
+        """
+        Check that counts are valid for the specific method.
+
+        Different methods may have different requirements.
+
+        Returns
+        -------
+        bool
+            True if counts are valid, False otherwise.
+        """
+        ...
 
     @abstractmethod
     def fit(self, **kwargs) -> None:

--- a/src/multi_condition_comparisions/tl/de.py
+++ b/src/multi_condition_comparisions/tl/de.py
@@ -46,6 +46,9 @@ class BaseMethod(ABC):
         # Check that counts have no NaN or Inf values.
         if np.any(np.isnan(self.adata.X)) or np.any(np.isinf(self.adata.X)):
             raise ValueError("Counts cannot contain NaN or Inf values.")
+        # Check that counts have numeric values.
+        if not np.issubdtype(self.adata.X.dtype, np.number):
+            raise ValueError("Counts must be numeric.")
 
         self.layer = layer
         if isinstance(design, str):

--- a/src/multi_condition_comparisions/tl/de.py
+++ b/src/multi_condition_comparisions/tl/de.py
@@ -175,6 +175,9 @@ class BaseMethod(ABC):
 class StatsmodelsDE(BaseMethod):
     """Differential expression test using a statsmodels linear regression"""
 
+    def _check_counts(self) -> bool:
+        return True
+
     def fit(
         self,
         regression_model: sm.OLS | sm.GLM = sm.OLS,
@@ -227,6 +230,10 @@ class StatsmodelsDE(BaseMethod):
 
 class EdgeRDE(BaseMethod):
     """Differential expression test using EdgeR"""
+
+    def _check_counts(self) -> bool:
+        # TODO: fill in with acutal EdgeR requirements
+        return True
 
     def fit(self, **kwargs):  # adata, design, mask, layer
         """

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -4,17 +4,23 @@ from pydeseq2.utils import load_example_data
 
 
 @pytest.fixture
-def test_adata():
-    counts = load_example_data(
+def test_counts():
+    return load_example_data(
         modality="raw_counts",
         dataset="synthetic",
         debug=False,
     )
 
-    metadata = load_example_data(
+
+@pytest.fixture
+def test_metadata():
+    return load_example_data(
         modality="metadata",
         dataset="synthetic",
         debug=False,
     )
 
-    return ad.AnnData(X=counts, obs=metadata)
+
+@pytest.fixture
+def test_adata(test_counts, test_metadata):
+    return ad.AnnData(X=test_counts, obs=test_metadata)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,20 @@
+import anndata as ad
+import pytest
+from pydeseq2.utils import load_example_data
+
+
+@pytest.fixture
+def test_adata():
+    counts = load_example_data(
+        modality="raw_counts",
+        dataset="synthetic",
+        debug=False,
+    )
+
+    metadata = load_example_data(
+        modality="metadata",
+        dataset="synthetic",
+        debug=False,
+    )
+
+    return ad.AnnData(X=counts, obs=metadata)

--- a/tests/test_de.py
+++ b/tests/test_de.py
@@ -1,9 +1,7 @@
-import anndata as ad
 import numpy as np
 import pytest
 import statsmodels.api as sm
 from pandas import testing as tm
-from pydeseq2.utils import load_example_data
 
 import multi_condition_comparisions
 from multi_condition_comparisions.tl.de import BaseMethod, StatsmodelsDE
@@ -11,23 +9,6 @@ from multi_condition_comparisions.tl.de import BaseMethod, StatsmodelsDE
 
 def test_package_has_version():
     assert multi_condition_comparisions.__version__ is not None
-
-
-@pytest.fixture
-def test_adata():
-    counts = load_example_data(
-        modality="raw_counts",
-        dataset="synthetic",
-        debug=False,
-    )
-
-    metadata = load_example_data(
-        modality="metadata",
-        dataset="synthetic",
-        debug=False,
-    )
-
-    return ad.AnnData(X=counts, obs=metadata)
 
 
 @pytest.mark.parametrize(

--- a/tests/test_edge_cases.py
+++ b/tests/test_edge_cases.py
@@ -5,10 +5,10 @@ import pytest
 from multi_condition_comparisions.tl.de import StatsmodelsDE
 
 
-@pytest.mark.parametrize("invalid_input", [np.nan, np.inf])
+@pytest.mark.parametrize("invalid_input", [np.nan, np.inf, "foo"])
 def test_invalid_inputs(invalid_input, test_counts, test_metadata):
     """Check that invalid inputs in MethodBase counts raise an error."""
     test_counts[0, 0] = invalid_input
     adata = ad.AnnData(X=test_counts, obs=test_metadata)
-    with pytest.raises(ValueError):
+    with pytest.raises((ValueError, TypeError)):
         StatsmodelsDE(adata=adata, design="~condition")

--- a/tests/test_edge_cases.py
+++ b/tests/test_edge_cases.py
@@ -1,0 +1,14 @@
+import anndata as ad
+import numpy as np
+import pytest
+
+from multi_condition_comparisions.tl.de import StatsmodelsDE
+
+
+@pytest.mark.parametrize("invalid_input", [-1, 0.1, np.nan, np.inf])
+def test_invalid_inputs(invalid_input, test_counts, test_metadata):
+    """Check that invalid inputs in MethodBase counts raise an error."""
+    test_counts[0, 0] = invalid_input
+    adata = ad.AnnData(X=test_counts, obs=test_metadata)
+    with pytest.raises(ValueError):
+        StatsmodelsDE(adata=adata, design="~condition")

--- a/tests/test_edge_cases.py
+++ b/tests/test_edge_cases.py
@@ -5,7 +5,7 @@ import pytest
 from multi_condition_comparisions.tl.de import StatsmodelsDE
 
 
-@pytest.mark.parametrize("invalid_input", [-1, 0.1, np.nan, np.inf])
+@pytest.mark.parametrize("invalid_input", [np.nan, np.inf])
 def test_invalid_inputs(invalid_input, test_counts, test_metadata):
     """Check that invalid inputs in MethodBase counts raise an error."""
     test_counts[0, 0] = invalid_input


### PR DESCRIPTION
This PR adds sanity checks on the counts that are passed to `MethodBase` objects (through the `adata` parameter).

Generic tests are performed by default, but each concrete class should now implement a `_check_counts` method to account for its own specificities (e.g. some might accept floats, but some only integers).